### PR TITLE
On delete story package assure that relation to content is also delet…

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,8 +84,8 @@ func main() {
 		spServiceUrl := "content-collection/story-package"
 		cpServiceUrl := "content-collection/content-package"
 		services := map[string]baseftrwapp.Service{
-			spServiceUrl: collection.NewContentCollectionService(db, []string{"Curation", "StoryPackage"}, "SELECTS"),
-			cpServiceUrl: collection.NewContentCollectionService(db, []string{}, "CONTAINS"),
+			spServiceUrl: collection.NewContentCollectionService(db, []string{"Curation", "StoryPackage"}, "SELECTS", "IS_CURATED_FOR"),
+			cpServiceUrl: collection.NewContentCollectionService(db, []string{}, "CONTAINS", ""),
 		}
 
 		for _, service := range services {


### PR DESCRIPTION
This is a fix for a potential problem when deleting story packages: before deleting a story package assure that the relation (IS_CURATED_FOR) from the story package to the content gets also deleted as that relation gets deleted from a parallel flow (content-rw-neo4j) and it might be executed after delete is executed on this content-collection-rw-neo4j service.