### PR TITLE
Content Collection deletion changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,103 +2,119 @@
 
 [![Circle CI](https://circleci.com/gh/Financial-Times/content-collection-rw-neo4j/tree/master.png?style=shield)](https://circleci.com/gh/Financial-Times/content-collection-rw-neo4j/tree/master)
 
-An API for reading/writing Content Collection entities into Neo4j. Expects the json supplied by the ingester.
+An API for reading/writing Content Collection entities into Neo4j.
+Expects the json supplied by the ingester.
 
-A content collection is a component created in Methode as story package or content package.
- 
+A content collection is a component created in Methode as story package or
+content package.
+
 The service currently exposes two endpoits:
 
-`http://host:port/content-collection/story-package` - for operations on story packages
+- for operations on story packages:
+`http://host:port/content-collection/story-package`
 
-`http://host:port/content-collection/content-package` - for operations on content packages
- 
-Functionally, the endpoints behave the same, the only difference being the labels and relations which are saved in **neo4j** by each.
- 
+- for operations on content packages:
+`http://host:port/content-collection/content-package`
+
+Functionally, the endpoints behave the same, the only difference being
+the labels and relations which are saved in **neo4j** by each.
+
 All endpoints support the following operations:
- 
-- **GET** with an UUID will retrieve the contents and relations of the neo4j node with the given uuid. The node and relation labels are dictated by the exact handler used.
-   
-e.g. the response for a GET request request to `http://host:port/content-collection/story-package/a403a332-de48-11e6-86ac-f253db7791c6`
+
+- **GET** with an UUID will retrieve the contents and relations
+of the neo4j node with the given uuid.
+The node and relation labels are dictated by the exact handler used.
+
+e.g. the response for a GET request request to
+`http://host:port/content-collection/story-package/a403a332-de48-11e6-86ac-f253db7791c6`
   
-```
+```json
 {
- 		"uuid": "a403a332-de48-11e6-86ac-f253db7791c6",
- 		"items": [{
- 			"uuid": "d4986a58-de3b-11e6-86ac-f253db7791c6"
- 		},
- 		{
- 			"uuid": "d9b4c4c6-dcc6-11e6-86ac-f253db7791c6"
- 		},
- 		{
- 			"uuid": "d8509dc8-d7ec-11e6-944b-e7eb37a6aa8e"
- 		},
- 		{
- 			"uuid": "404040aa-ce97-11e6-864f-20dcb35cede2"
- 		},
- 		{ 			
- 		    "uuid": "834a2bc2-bd67-11e6-8b45-b8b81dd5d080"
- 		}],
- 		"publishReference": "tdi23377744",
- 		"lastModified": "2017-01-31T15:33:21.687Z"
+    "uuid": "a403a332-de48-11e6-86ac-f253db7791c6",
+    "items": [{
+        "uuid": "d4986a58-de3b-11e6-86ac-f253db7791c6"
+    },
+    {
+        "uuid": "d9b4c4c6-dcc6-11e6-86ac-f253db7791c6"
+    },
+    {
+        "uuid": "d8509dc8-d7ec-11e6-944b-e7eb37a6aa8e"
+    },
+    {
+        "uuid": "404040aa-ce97-11e6-864f-20dcb35cede2"
+    },
+    {
+        "uuid": "834a2bc2-bd67-11e6-8b45-b8b81dd5d080"
+    }],
+    "publishReference": "tdi23377744",
+    "lastModified": "2017-01-31T15:33:21.687Z"
 }
 ```
 
 In case no node with the given uuid is available, a `404` status code is returned.
-  
-  
-- **PUT** with an UUID and a json payload will create a node in neo4j and the associated relations. The node and relation labels are dictated by the exact handler used.
-In case a node already exists, it will be updated.
- 
-e.g. a PUT request to `http://host:port/content-collection/story-package/a403a332-de48-11e6-86ac-f253db7791c6` with the following payload:
 
-```
+- **PUT** with an UUID and a json payload will create a node in neo4j
+and the associated relations.
+The node and relation labels are dictated by the exact handler used.
+In case a node already exists, it will be updated.
+
+e.g. a PUT request to `http://host:port/content-collection/story-package/a403a332-de48-11e6-86ac-f253db7791c6`
+with the following payload:
+
+```json
 {
- 		"uuid": "a403a332-de48-11e6-86ac-f253db7791c6",
- 		"items": [{
- 			"uuid": "d4986a58-de3b-11e6-86ac-f253db7791c6"
- 		},
- 		{
- 			"uuid": "d9b4c4c6-dcc6-11e6-86ac-f253db7791c6"
- 		},
- 		{
- 			"uuid": "d8509dc8-d7ec-11e6-944b-e7eb37a6aa8e"
- 		},
- 		{
- 			"uuid": "404040aa-ce97-11e6-864f-20dcb35cede2"
- 		},
- 		{ 			
- 		    "uuid": "834a2bc2-bd67-11e6-8b45-b8b81dd5d080"
- 		}],
- 		"publishReference": "tdi23377744",
- 		"lastModified": "2017-01-31T15:33:21.687Z"
+    "uuid": "a403a332-de48-11e6-86ac-f253db7791c6",
+    "items": [{
+        "uuid": "d4986a58-de3b-11e6-86ac-f253db7791c6"
+    },
+    {
+        "uuid": "d9b4c4c6-dcc6-11e6-86ac-f253db7791c6"
+    },
+    {
+        "uuid": "d8509dc8-d7ec-11e6-944b-e7eb37a6aa8e"
+    },
+    {
+        "uuid": "404040aa-ce97-11e6-864f-20dcb35cede2"
+    },
+    {
+        "uuid": "834a2bc2-bd67-11e6-8b45-b8b81dd5d080"
+    }],
+    "publishReference": "tdi23377744",
+    "lastModified": "2017-01-31T15:33:21.687Z"
 }
 ```
+
 should result in a `200` status code response.
 
-- **DELETE** with an UUID will delete the neo4j node with the given uuid alongside all its relations.
+- **DELETE** with an UUID will delete the neo4j node
+with the given uuid alongside all its relations.
 
-e.g. a DELETE request to `http://host:port/content-collection/story-package/a403a332-de48-11e6-86ac-f253db7791c6` 
-will result in a `204` status code if the node has been deleted or in a `404` status code if there was no 
-node with the given uuid.
+e.g. a DELETE request to `http://host:port/content-collection/story-package/a403a332-de48-11e6-86ac-f253db7791c6`
+will result in a `204` status code if the node has been deleted or
+in a `404` status code if there was no node with the given uuid.
 
-- **GET** on the `__count` path of a handler will return the number of nodes currenly in neo4j. The labels of the nodes counted 
-depend on the exact handler used.
+- **GET** on the `__count` path of a handler will return
+the number of nodes currently in neo4j.
+The labels of the nodes counted depend on the exact handler used.
 
-e.g. a GET request to `http://host:port/content-collection/story-package/__count` will return 
-the number of story package nodes currently in neo4j. The response is not json formatted, it is simply a number
-like `10` or `0`. 
+e.g. a GET request to `http://host:port/content-collection/story-package/__count`
+will return the number of story package nodes currently in neo4j.
+The response is not json formatted, it is simply a number like `10` or `0`.
 
 ## How to test
 
-To run the full test suite of tests, you must have a running instance of neo4j. By default the application will look for the elasticsearch instance at http://neo4j:7474/db/data. Otherwise you could specify a URL yourself as given by the example below:
+To run the full test suite of tests, you must have a running instance of neo4j.
+By default the application will look for the elasticsearch instance at <http://neo4j:7474/db/data>.
+Otherwise you could specify a URL yourself as given by the example below:
 
-```
+```shell
 export NEO4J_TEST_URL=http://neo4j:7474/db/data
 ```
 
-* Unit tests only: `go test -mod=readonly -race ./...`
-* Unit and integration tests:
-    ```
+- Unit tests only: `go test -mod=readonly -race ./...`
+- Unit and integration tests:
+
+    ```shell
     docker-compose -f docker-compose-tests.yml up -d --build && \
     docker logs -f test-runner && \
     docker-compose -f docker-compose-tests.yml down -v


### PR DESCRIPTION
# Description

## What

The logic for how Content Collection deletion is handled is changed:
- What is the same that all its outbound CONTAINS relations are deleted (the collection is empty).
- The changed query is that its `ContentCollection` labeled is removed.
- And then if there are no remaining relations (e.g. `ContentPackage` is not related to it), the node is also deleted.
- If that is not the case, the node is left as `Thing`, so the relation with the `ContentPackage` doesn't get destroyed.

## Why

Full description in the [JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-1908).

## Anything, in particular, you'd like to highlight to reviewers

This is not deployed on dev as it interferes with the notifications changes currently in development, which are with higher priority.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
